### PR TITLE
Fix reviewed way count

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -435,7 +435,6 @@ const App: React.FC = () => {
       />
       <UploadModal
         show={showFinishedModal && !latestChangeset}
-        ways={currentWay}
         onClose={() => setShowFinishedModal(false)}
         uploads={uploadWays}
         setUploadWays={setUploadWays}

--- a/src/components/UploadModal.tsx
+++ b/src/components/UploadModal.tsx
@@ -13,7 +13,6 @@ import { useChangesetStore } from "../stores/useChangesetStore";
 
 interface UploadModalProps {
   show: boolean;
-  ways: number;
   onClose: () => void;
   uploads: OsmWay[];
   setUploadWays: (ways: OsmWay[]) => void;
@@ -23,7 +22,6 @@ interface UploadModalProps {
 
 const UploadModal: React.FC<UploadModalProps> = ({
   show,
-  ways,
   onClose,
   uploads,
   setUploadWays,
@@ -83,7 +81,7 @@ const UploadModal: React.FC<UploadModalProps> = ({
       >
         <div className="space-y-6">
           <div className="flex flex-col items-center gap-2">
-            <WayCountBadge count={ways} verb="reviewed" />
+            <WayCountBadge count={uploads.length} verb="reviewed" />
             <p className="text-center text-medium font-medium">
               The changes you upload as
               <Link


### PR DESCRIPTION
The reviewed way count in the upload modal showed the incorrect number of ways. This has been fixed by using the number of entries in the upload queue, similar to the badge in the "Upload" button at the bottom.

<img width="474" height="178" alt="image" src="https://github.com/user-attachments/assets/a53bda80-0495-434d-895f-dfde1389ece9" />
