### PR TITLE
Fix overzoom, fix small ways not loading map tiles, and add imagery fallback

### DIFF
--- a/src/components/WayMap.tsx
+++ b/src/components/WayMap.tsx
@@ -35,15 +35,20 @@ const WayMap: React.FC<WayMapProps> = ({
     // Calculate center point from coordinates
     const bounds = coordinates.length
       ? coordinates.reduce(
-          (bounds, coord) => bounds.extend(coord),
-          new maplibregl.LngLatBounds(coordinates[0], coordinates[0]),
-        )
+        (bounds, coord) => bounds.extend(coord),
+        new maplibregl.LngLatBounds(coordinates[0], coordinates[0]),
+      )
       : new maplibregl.LngLatBounds(
-          [-124.848974, 24.396308],
-          [-66.885444, 49.384358],
-        );
+        [-124.848974, 24.396308],
+        [-66.885444, 49.384358],
+      );
 
     setImagery(TILE_SOURCES[selectedSourceId].name);
+
+
+    const sourceMaxZoom = Object.values(TILE_SOURCES).find(
+      (source) => source.url === tileSource,
+    )?.maxZoom || 22;
 
     // Initialize the map
     map.current = new maplibregl.Map({
@@ -59,10 +64,7 @@ const WayMap: React.FC<WayMapProps> = ({
               Object.values(TILE_SOURCES).find(
                 (source) => source.url === tileSource,
               )?.attribution?.text || "OpenStreetMap contributors",
-            maxzoom:
-              Object.values(TILE_SOURCES).find(
-                (source) => source.url === tileSource,
-              )?.maxZoom || 22,
+            maxzoom: sourceMaxZoom
           },
         },
         layers: [
@@ -71,12 +73,15 @@ const WayMap: React.FC<WayMapProps> = ({
             type: "raster",
             source: "raster-tiles",
             minzoom: 0,
-            maxzoom: 22,
+            maxzoom: 24,
           },
         ],
       },
       bounds: bounds,
-      fitBoundsOptions: { padding: 50 },
+      fitBoundsOptions: {
+        padding: 50,
+        maxZoom: Math.min(sourceMaxZoom, 20)
+      },
     });
 
     map.current.on("load", () => {

--- a/src/components/WayMap.tsx
+++ b/src/components/WayMap.tsx
@@ -37,13 +37,13 @@ const WayMap: React.FC<WayMapProps> = ({
     // Calculate center point from coordinates
     const bounds = coordinates.length
       ? coordinates.reduce(
-        (bounds, coord) => bounds.extend(coord),
-        new maplibregl.LngLatBounds(coordinates[0], coordinates[0]),
-      )
+          (bounds, coord) => bounds.extend(coord),
+          new maplibregl.LngLatBounds(coordinates[0], coordinates[0]),
+        )
       : new maplibregl.LngLatBounds(
-        [-124.848974, 24.396308],
-        [-66.885444, 49.384358],
-      );
+          [-124.848974, 24.396308],
+          [-66.885444, 49.384358],
+        );
 
     // Check if current imagery covers the new location and switch if needed
     if (coordinates.length > 0) {
@@ -55,7 +55,7 @@ const WayMap: React.FC<WayMapProps> = ({
       );
 
       const currentSourceAvailable = visibleFeatures.some(
-        feature => feature.properties?.id === selectedSourceId
+        (feature) => feature.properties?.id === selectedSourceId,
       );
 
       if (!currentSourceAvailable) {
@@ -65,7 +65,6 @@ const WayMap: React.FC<WayMapProps> = ({
     }
 
     setImagery(TILE_SOURCES[selectedSourceId].name);
-
 
     const currentTileSource = TILE_SOURCES[selectedSourceId]?.url || "";
     const sourceMaxZoom = TILE_SOURCES[selectedSourceId]?.maxZoom || 22;
@@ -81,8 +80,9 @@ const WayMap: React.FC<WayMapProps> = ({
             tiles: [currentTileSource],
             tileSize: 256,
             attribution:
-              TILE_SOURCES[selectedSourceId]?.attribution?.text || "OpenStreetMap contributors",
-            maxzoom: sourceMaxZoom
+              TILE_SOURCES[selectedSourceId]?.attribution?.text ||
+              "OpenStreetMap contributors",
+            maxzoom: sourceMaxZoom,
           },
         },
         layers: [
@@ -98,7 +98,7 @@ const WayMap: React.FC<WayMapProps> = ({
       bounds: bounds,
       fitBoundsOptions: {
         padding: 50,
-        maxZoom: Math.min(sourceMaxZoom, 19)
+        maxZoom: Math.min(sourceMaxZoom, 19),
       },
     });
 


### PR DESCRIPTION
This PR fixes an issue where zooming in too far on certain imagery layers would cause the entire imagery layer to go black. This has been fixed by setting the max zoom to 24 (MabLibre maximum), allowing the user to zoom in more without attempting to load non-existent tiles.

This also fixes an issue where loading small ways would cause the map to be zoomed in too much and not load any imagery until you manually zoomed in or out.

Finally, this PR also adds an imagery fallback mechanism so if the imagery you were using is not available at the location of the next way to review, it will fall back to a known good imagery (usually Esri World Imagery). This is common - for example - in Hawaii with Maui County Orthoimagery being available in Maui, but then not available when reviewing a way somewhere else in the state.

Sorry for the 3-in-1, got a bit carried away 😅