### PR TITLE
Add additional keybinds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,9 +117,9 @@ const App: React.FC = () => {
   useEffect(() => {
     setHost(
       window.location.protocol +
-      "//" +
-      window.location.host +
-      window.location.pathname,
+        "//" +
+        window.location.host +
+        window.location.pathname,
     );
   }, [setHost]);
 
@@ -409,10 +409,10 @@ const App: React.FC = () => {
           }
           break;
         case "b":
-          handleActions.fix('bad geometry');
+          handleActions.fix("bad geometry");
           break;
         case "s":
-          handleActions.fix('needs splitting');
+          handleActions.fix("needs splitting");
           break;
         case "d":
           handleActions.fix("doesn't exist");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -417,6 +417,9 @@ const App: React.FC = () => {
         case "d":
           handleActions.fix("doesn't exist");
           break;
+        case "c":
+          handleActions.fix("check highway value")
+          break;
         default:
           break;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -396,28 +396,29 @@ const App: React.FC = () => {
       // Only handle keypress if logged in
       if (!loggedIn) return;
 
-      if (event.key === "u") {
-        setShowFinishedModal(true);
-      } else if (event.key === "f") {
-        handleActions.clearTiger();
-      } else if (
-        event.key === "Enter" &&
-        surface &&
-        (lanes || laneMarkings == false)
-      ) {
-        handleActions.submit();
-      } else if (
-        event.key === "b"
-      ) {
-        handleActions.fix('bad geometry');
-      } else if (
-        event.key === "s"
-      ) {
-        handleActions.fix('needs splitting');
-      } else if (
-        event.key === "d"
-      ) {
-        handleActions.fix('doesn\'t exist');
+      switch (event.key) {
+        case "u":
+          setShowFinishedModal(true);
+          break;
+        case "f":
+          handleActions.clearTiger();
+          break;
+        case "Enter":
+          if (surface && (lanes || laneMarkings == false)) {
+            handleActions.submit();
+          }
+          break;
+        case "b":
+          handleActions.fix('bad geometry');
+          break;
+        case "s":
+          handleActions.fix('needs splitting');
+          break;
+        case "d":
+          handleActions.fix("doesn't exist");
+          break;
+        default:
+          break;
       }
     };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -418,7 +418,7 @@ const App: React.FC = () => {
           handleActions.fix("doesn't exist");
           break;
         case "c":
-          handleActions.fix("check highway value")
+          handleActions.fix("check highway value");
           break;
         default:
           break;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,9 +117,9 @@ const App: React.FC = () => {
   useEffect(() => {
     setHost(
       window.location.protocol +
-        "//" +
-        window.location.host +
-        window.location.pathname,
+      "//" +
+      window.location.host +
+      window.location.pathname,
     );
   }, [setHost]);
 
@@ -405,8 +405,19 @@ const App: React.FC = () => {
         surface &&
         (lanes || laneMarkings == false)
       ) {
-        console.log("Pressed s");
         handleActions.submit();
+      } else if (
+        event.key === "b"
+      ) {
+        handleActions.fix('bad geometry');
+      } else if (
+        event.key === "s"
+      ) {
+        handleActions.fix('needs splitting');
+      } else if (
+        event.key === "d"
+      ) {
+        handleActions.fix('doesn\'t exist');
       }
     };
 

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -29,6 +29,21 @@ const keyboardShortcuts = [
   },
 ];
 
+const fixShortcuts = [
+  {
+    keys: ["b"],
+    description: "Bad geometry",
+  },
+  {
+    keys: ["s"],
+    description: "Needs splitting",
+  },
+  {
+    keys: ["d"],
+    description: "Doesn't exist",
+  },
+];
+
 const commonActions = [
   {
     title: "Skip",
@@ -109,6 +124,29 @@ const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
           </div>
           <div className="grid grid-cols-2 gap-2">
             {keyboardShortcuts.map((shortcut, index) => (
+              <div
+                key={index}
+                className="bg-default-100 p-2 rounded flex flex-row"
+              >
+                <div className="flex gap-2">
+                  {shortcut.keys.map((key, keyIndex) => (
+                    <Kbd
+                      key={keyIndex}
+                      className="bg-default-200 px-2 py-1 rounded"
+                    >
+                      {key}
+                    </Kbd>
+                  ))}
+                </div>
+                <span className="ml-2">{shortcut.description}</span>
+              </div>
+            ))}
+          </div>
+          <div className="gap-4 items-center my-2">
+            <h3 className="text-md font-semibold">Fix Shortcuts</h3>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {fixShortcuts.map((shortcut, index) => (
               <div
                 key={index}
                 className="bg-default-100 p-2 rounded flex flex-row"

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -42,6 +42,10 @@ const fixShortcuts = [
     keys: ["d"],
     description: "Doesn't exist",
   },
+  {
+    keys: ["c"],
+    description: "Check highway value",
+  },
 ];
 
 const commonActions = [

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -68,7 +68,7 @@ const LeftPane: React.FC<LeftPaneProps> = ({
     { key: "bad-geometry", label: "Bad geometry", keybind: "b" },
     { key: "needs-splitting", label: "Needs splitting", keybind: "s" },
     { key: "doesnt-exist", label: "Doesn't exist", keybind: "d" },
-    { key: "check-highway", label: "Check highway value" },
+    { key: "check-highway", label: "Check highway value", keybind: "c" },
   ];
   const { relation } = useChangesetStore();
   const { lanes, surface, laneMarkings } = useWayTagsStore();

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -245,12 +245,15 @@ const LeftPane: React.FC<LeftPaneProps> = ({
                               onPress={() =>
                                 handleFix(option.label.toLowerCase())
                               }
+                              textValue={option.label}
                             >
-                              <div className="flex gap-2 items-center">
+                              <div className="flex gap-2 items-center justify-between">
                                 <p>{option.label}</p>
-                                <Kbd className="hidden md:block">
-                                  {option.keybind}
-                                </Kbd>
+                                {option.keybind && (
+                                  <Kbd className="hidden md:block">
+                                    {option.keybind}
+                                  </Kbd>
+                                )}
                               </div>
                             </DropdownItem>
                           ))}

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -65,9 +65,9 @@ const LeftPane: React.FC<LeftPaneProps> = ({
   const [isFixModalOpen, setIsFixModalOpen] = useState(false);
   const [customFixMessage, setCustomFixMessage] = useState("");
   const fixOptions = [
-    { key: "bad-geometry", label: "Bad geometry" },
-    { key: "needs-splitting", label: "Needs splitting" },
-    { key: "doesnt-exist", label: "Doesn't exist" },
+    { key: "bad-geometry", label: "Bad geometry", keybind: 'b' },
+    { key: "needs-splitting", label: "Needs splitting", keybind: 's' },
+    { key: "doesnt-exist", label: "Doesn't exist", keybind: 'd' },
     { key: "check-highway", label: "Check highway value" },
   ];
   const { relation } = useChangesetStore();
@@ -246,7 +246,10 @@ const LeftPane: React.FC<LeftPaneProps> = ({
                                 handleFix(option.label.toLowerCase())
                               }
                             >
-                              {option.label}
+                              <div className="flex gap-2 items-center">
+                                <p>{option.label}</p>
+                                <Kbd className="hidden md:block">{option.keybind}</Kbd>
+                              </div>
                             </DropdownItem>
                           ))}
                         </>

--- a/src/components/LeftPane.tsx
+++ b/src/components/LeftPane.tsx
@@ -65,9 +65,9 @@ const LeftPane: React.FC<LeftPaneProps> = ({
   const [isFixModalOpen, setIsFixModalOpen] = useState(false);
   const [customFixMessage, setCustomFixMessage] = useState("");
   const fixOptions = [
-    { key: "bad-geometry", label: "Bad geometry", keybind: 'b' },
-    { key: "needs-splitting", label: "Needs splitting", keybind: 's' },
-    { key: "doesnt-exist", label: "Doesn't exist", keybind: 'd' },
+    { key: "bad-geometry", label: "Bad geometry", keybind: "b" },
+    { key: "needs-splitting", label: "Needs splitting", keybind: "s" },
+    { key: "doesnt-exist", label: "Doesn't exist", keybind: "d" },
     { key: "check-highway", label: "Check highway value" },
   ];
   const { relation } = useChangesetStore();
@@ -248,7 +248,9 @@ const LeftPane: React.FC<LeftPaneProps> = ({
                             >
                               <div className="flex gap-2 items-center">
                                 <p>{option.label}</p>
-                                <Kbd className="hidden md:block">{option.keybind}</Kbd>
+                                <Kbd className="hidden md:block">
+                                  {option.keybind}
+                                </Kbd>
                               </div>
                             </DropdownItem>
                           ))}


### PR DESCRIPTION
This PR adds key binds for the following fix options:

- bad geometry
- needs splitting
- doesn't exist

The if statement for determining which key was pressed has also been changed to a switch statement.

In the future, it may be best to extract the key bind functionality to its own file and pass the entry key ('bad-geometry') to the fix function rather than a raw message string.