### PR TITLE
Load way line and arrows before the map tiles finish loading

### DIFF
--- a/src/components/WayMap.tsx
+++ b/src/components/WayMap.tsx
@@ -102,7 +102,7 @@ const WayMap: React.FC<WayMapProps> = ({
       },
     });
 
-    map.current.on("load", () => {
+    map.current.on("style.load", () => {
       // Add the line source
       map.current?.addSource("way-line", {
         type: "geojson",


### PR DESCRIPTION
This PR makes a very small change to load the way line and arrows when the map style loads, rather than once all the tiles have loaded. This allows you to start reviewing the way while tiles are still being loaded in other places of the map.