### PR TITLE
Add lane count badge to "other" lane count button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "tigerking",
-  "private": true,
-  "version": "0.5.1",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "vite preview",
-    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\""
-  },
-  "dependencies": {
-    "@heroui/react": "^2.6.13",
-    "@turf/boolean-point-in-polygon": "^7.2.0",
-    "@turf/helpers": "^7.2.0",
-    "js-cookie": "^3.0.5",
-    "maplibre-gl": "^4.7.1",
-    "osm-auth": "^2.5.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "xmlbuilder2": "^3.1.1",
-    "zustand": "^5.0.2"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.15.0",
-    "@types/js-cookie": "^3.0.6",
-    "@types/maplibre-gl": "^1.13.2",
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.4",
-    "autoprefixer": "^10.4.20",
-    "eslint": "^9.15.0",
-    "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-react-refresh": "^0.4.14",
-    "globals": "^15.12.0",
-    "postcss": "^8.4.49",
-    "prettier": "^3.6.2",
-    "tailwindcss": "^3.4.17",
-    "typescript": "~5.6.2",
-    "typescript-eslint": "^8.15.0",
-    "vite": "^6.0.1"
-  }
+	"name": "tigerking",
+	"private": true,
+	"version": "0.5.1",
+	"type": "module",
+	"scripts": {
+		"dev": "vite --host 127.0.0.1",
+		"build": "tsc -b && vite build",
+		"lint": "eslint .",
+		"preview": "vite preview",
+		"format": "prettier --write \"src/**/*.{ts,tsx,js,jsx}\"",
+		"format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\""
+	},
+	"dependencies": {
+		"@heroui/react": "^2.6.13",
+		"@turf/boolean-point-in-polygon": "^7.2.0",
+		"@turf/helpers": "^7.2.0",
+		"js-cookie": "^3.0.5",
+		"maplibre-gl": "^4.7.1",
+		"osm-auth": "^2.5.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1",
+		"xmlbuilder2": "^3.1.1",
+		"zustand": "^5.0.2"
+	},
+	"devDependencies": {
+		"@eslint/js": "^9.15.0",
+		"@types/js-cookie": "^3.0.6",
+		"@types/maplibre-gl": "^1.13.2",
+		"@types/react": "^18.3.12",
+		"@types/react-dom": "^18.3.1",
+		"@vitejs/plugin-react": "^4.3.4",
+		"autoprefixer": "^10.4.20",
+		"eslint": "^9.15.0",
+		"eslint-plugin-react-hooks": "^5.0.0",
+		"eslint-plugin-react-refresh": "^0.4.14",
+		"globals": "^15.12.0",
+		"postcss": "^8.4.49",
+		"prettier": "^3.6.2",
+		"tailwindcss": "^3.4.17",
+		"typescript": "~5.6.2",
+		"typescript-eslint": "^8.15.0",
+		"vite": "^6.0.1"
+	}
 }

--- a/src/components/LanesButtons.tsx
+++ b/src/components/LanesButtons.tsx
@@ -94,6 +94,9 @@ const LanesButtons: React.FC<LanesButtonsProps> = ({
             ),
             () => setShowLaneDirection(!showLaneDirection),
             true,
+            <p className="px-1.5 py-0.5 mt-0.5 bg-gray-600 rounded-lg text-xs">
+              {lanes}
+            </p>,
           )}
         </ButtonGroup>
       </div>

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@heroui/button";
+import { ReactNode } from "react";
 import kebab from "../assets/kebab.svg";
 
 const toggleButton = (
@@ -6,15 +7,12 @@ const toggleButton = (
   isActive: boolean,
   onPress?: () => void,
   isIconOnly: boolean = false,
+  slot?: ReactNode,
 ) => (
   <Button
     key={label}
     variant="bordered"
-    className={`flex-1 border-1 transition-all duration-200 ${
-      isActive
-        ? "bg-primary-100 shadow-lg border-primary"
-        : "hover:bg-primary/10"
-    }`}
+    className={`flex-1 border-1 transition-all duration-200 ${isActive ? "bg-primary-100 shadow-lg border-primary" : "hover:bg-primary/10"}`}
     onPress={onPress}
     isIconOnly={isIconOnly}
   >
@@ -25,7 +23,10 @@ const toggleButton = (
         className="h-6 w-6 brightness-0 dark:brightness-100 dark:invert"
       />
     ) : (
-      label
+      <div className="flex items-center gap-2">
+        <span>{label}</span>
+        {slot}
+      </div>
     )}
   </Button>
 );


### PR DESCRIPTION
Small PR that adds a little badge on the "other" lane count button that shows how many lanes are selected. Useful for when you come across a road that's already had its lane count tagged and want to verify without opening the lane selector.